### PR TITLE
Use <= instead of << for loop termination condition.

### DIFF
--- a/iec18004.c
+++ b/iec18004.c
@@ -807,7 +807,7 @@ ui8 *qr_encode_opts(
       set(8, 7, (fcode & (1 << 6)) ? 1 : 0);
       for (n = 0; n <= 7; n++)
          set(w - n - 1, 8, (fcode & (1 << n)) ? 1 : 0);
-      for (n = 8; n << 14; n++)
+      for (n = 8; n <= 14; n++)
          set(8, w - (14 - n) - 1, (fcode & (1 << n)) ? 1 : 0);
    }
    setfcode(o.mask);


### PR DESCRIPTION
Causes setfcode to loop a few too many times but does not seem to
change the actual code output. Fixing this reduces the execution
time of qr from around 12ms to 5ms.

without fix applied

time ./qr -c "Hello Mum" --overlay "/tmp/abc" --png -o /tmp/mum.png

real	0m0.012s
user	0m0.012s
sys	0m0.000s

with fix applied

time ./qr -c "Hello Mum" --overlay "/tmp/abc" --png -o /tmp/mum9.png

real	0m0.005s
user	0m0.000s
sys	0m0.005s